### PR TITLE
Add multi id support for cmd

### DIFF
--- a/python/ssrcli/cmd.py
+++ b/python/ssrcli/cmd.py
@@ -10,9 +10,9 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument('-v', '--version', action='version', version='%(prog)s {}'.format(config.VERSION))
     parser.add_argument('model', choices=['conf', 'sub'], help='choose which kind of resources to manage')
     parser.add_argument(
-        'action', choices=['get', 'ls', 'add', 'rm', 'edit', 'take', 'update'], help='choose which action to take',
-    )
-    parser.add_argument('-i', '--id', type=int, help='give instance id', dest='ins_id')
+        'action', choices=['ls', 'add', 'rm', 'edit', 'take', 'update', 'get'], help='choose which action to take')
+    # `get` is deprecated
+    parser.add_argument('-i', '--id', type=int, action='append', help='give instance id', dest='ins_id')
     parser.add_argument('-j', '--json', help='give instance json-format information', dest='ins_json')
     parser.add_argument('-u', '--url', help='give SSR sharing URL', dest='ssr_url')
     return parser

--- a/tests/python/ssrcli_test/test_cmd_conf.py
+++ b/tests/python/ssrcli_test/test_cmd_conf.py
@@ -25,6 +25,7 @@ def test_add_conf():
     assert query_result[0] == 1
 
 
+# `get` is deprecated
 @init_conf_table
 def test_get_conf():
     subprocess.run(CMD_PREFIX + ['conf', 'add', '-j', json.dumps(SSR_CONF['info'])], env=VENV_ENV)
@@ -33,7 +34,14 @@ def test_get_conf():
 
 
 @init_conf_table
-def test_list_conf():
+def test_list_some_conf():
+    subprocess.run(CMD_PREFIX + ['conf', 'add', '-j', json.dumps(SSR_CONF['info'])], env=VENV_ENV)
+    process = subprocess.run(CMD_PREFIX + ['conf', 'ls', '-i', '1'], capture_output=True, env=VENV_ENV)
+    assert 'remarks: test' in process.stdout.decode('utf-8')
+
+
+@init_conf_table
+def test_list_all_conf():
     subprocess.run(CMD_PREFIX + ['conf', 'add', '-j', json.dumps(SSR_CONF['info'])], env=VENV_ENV)
     subprocess.run(CMD_PREFIX + ['conf', 'add', '-j', json.dumps(SSR_CONF['info'])], env=VENV_ENV)
     process = subprocess.run(CMD_PREFIX + ['conf', 'ls'], capture_output=True, env=VENV_ENV)

--- a/tests/python/ssrcli_test/test_cmd_sub.py
+++ b/tests/python/ssrcli_test/test_cmd_sub.py
@@ -29,6 +29,7 @@ def test_add_sub():
     assert query_result[0] == 1
 
 
+# `get` is deprecated
 @init_sub_table
 def test_get_sub():
     subprocess.run(CMD_PREFIX + ['sub', 'add', '-j', json.dumps(SSR_SUB)], env=VENV_ENV)
@@ -37,7 +38,14 @@ def test_get_sub():
 
 
 @init_sub_table
-def test_list_sub():
+def test_list_some_sub():
+    subprocess.run(CMD_PREFIX + ['sub', 'add', '-j', json.dumps(SSR_SUB)], env=VENV_ENV)
+    process = subprocess.run(CMD_PREFIX + ['sub', 'ls', '-i', '1'], capture_output=True, env=VENV_ENV)
+    assert 'name: test' in process.stdout.decode('utf-8')
+
+
+@init_sub_table
+def test_list_all_sub():
     subprocess.run(CMD_PREFIX + ['sub', 'add', '-j', json.dumps(SSR_SUB)], env=VENV_ENV)
     subprocess.run(CMD_PREFIX + ['sub', 'add', '-j', json.dumps(SSR_SUB)], env=VENV_ENV)
     process = subprocess.run(CMD_PREFIX + ['sub', 'ls'], capture_output=True, env=VENV_ENV)


### PR DESCRIPTION
Mark `get` as deprecated. Use `ls` to replace it.